### PR TITLE
Updated Dockerfile for YSTEMandChess Angular app

### DIFF
--- a/YStemAndChess/Dockerfile
+++ b/YStemAndChess/Dockerfile
@@ -15,7 +15,7 @@ WORKDIR /usr/src/app
 
 COPY package*.json ./
 
-RUN npm install -g @angular/cli@9.1.8 @angular-devkit/build-angular && npm install
+RUN npm install -g @angular/cli@9.1.13 @angular-devkit/build-angular && npm install
 
 COPY . .
 


### PR DESCRIPTION
Error Fix:
1. Unable to start the ystemandchess frontend angular app ( minimum @angular/cli@9.1.13 was required to run the app but docker file installed @angular/cli@9.1.8 )